### PR TITLE
Update OutputPath

### DIFF
--- a/Primavera.Sales.Invoice/Primavera.Sales.Invoice.csproj
+++ b/Primavera.Sales.Invoice/Primavera.Sales.Invoice.csproj
@@ -35,7 +35,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\..\Program Files %28x86%29\PRIMAVERA\SG100\Apl\</OutputPath>
+    <OutputPath>C:\Program Files (x86)\PRIMAVERA\SG100\Apl\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>


### PR DESCRIPTION
Relative OutputPath causes conflicts because depends on where the project is located on the disk.