### PR TITLE
Update frmInvoice.cs

### DIFF
--- a/Primavera.Sales.Invoice/User Interface/frmInvoice.cs
+++ b/Primavera.Sales.Invoice/User Interface/frmInvoice.cs
@@ -162,8 +162,8 @@ namespace Primavera.Sales.Invoice
 
                 if (campos != null)
                 {
-                    txtNome.Text = campos[0].Valor;
-                    txtNif.Text = campos[1].Valor;
+                    txtNome.Text = campos[0].Valor.ToString();
+                    txtNif.Text = campos[1].Valor.ToString();
                 }
             }
         }


### PR DESCRIPTION
Na linha 165 e 166 o a variáveis  txtNome e txtNif estão a aguardar por texto.
Erro: Cannot implicitly convert type 'object' to 'string'. An explicit conversion exists (are you missing a cast?)

Foi adicionado o método ToString()
 - txtNome.Text = campos[0].Valor.ToString();
 - txtNif.Text = campos[1].Valor.ToString();

Alternativa pode-se fazer um cast. 
 - txtNome.Text = (string)campos[0].Valor;
 - txtNif.Text = (string)campos[1].Valor.ToString();