### PR TITLE
Update CurrentDomain_AssemblyResolve  in Program.cs

### DIFF
--- a/ERP/Program.cs
+++ b/ERP/Program.cs
@@ -28,16 +28,88 @@ namespace Primavera.Erp.Sample
         static System.Reflection.Assembly CurrentDomain_AssemblyResolve(object sender, ResolveEventArgs args)
         {
             string assemblyFullName;
-            
-            System.Reflection.AssemblyName assemblyName;
-            
-            assemblyName = new System.Reflection.AssemblyName(args.Name);
-            assemblyFullName = System.IO.Path.Combine(Environment.GetEnvironmentVariable("PERCURSOSGE100", EnvironmentVariableTarget.Machine), assemblyName.Name + ".dll");
-            
-            if (System.IO.File.Exists(assemblyFullName))
-                return System.Reflection.Assembly.LoadFile(assemblyFullName);
+            string assemblyProgramFilesX86FullName;
+            string assemblyProgramFilesFullName;
+            AssemblyName assemblyName;
+
+            string PRIMAVERA_FOLDER = "PRIMAVERA\\SG100\\Apl";
+            string environmentVariablesProgramFilesX86 = Environment.ExpandEnvironmentVariables("%ProgramFiles(x86)%");
+            string environmentVariablesProgramFiles = Environment.ExpandEnvironmentVariables("%ProgramW6432%");
+
+            assemblyName = new AssemblyName(args.Name);
+
+            var PERCURSOSGE100 = Environment.GetEnvironmentVariable("PERCURSOSGE100", EnvironmentVariableTarget.Machine);
+
+            if (!string.IsNullOrWhiteSpace(PERCURSOSGE100))
+            {
+                assemblyFullName = Path.Combine(PERCURSOSGE100, assemblyName.Name + ".dll");
+            }
             else
-                return null;
+            {
+                assemblyFullName = Path.Combine(Path.Combine(@"C:\", PRIMAVERA_FOLDER), assemblyName.Name + ".dll");
+            }
+
+            assemblyProgramFilesX86FullName = Path.Combine(Path.Combine(environmentVariablesProgramFilesX86, PRIMAVERA_FOLDER), assemblyName.Name + ".dll");
+            assemblyProgramFilesFullName = Path.Combine(Path.Combine(environmentVariablesProgramFiles, PRIMAVERA_FOLDER), assemblyName.Name + ".dll");
+
+            if (File.Exists(assemblyFullName))
+            {
+                return Assembly.LoadFile(assemblyFullName);
+            }
+            else if (File.Exists(assemblyProgramFilesX86FullName))
+            {
+                return Assembly.LoadFile(assemblyProgramFilesX86FullName);
+            }
+            else if (File.Exists(assemblyProgramFilesFullName))
+            {
+                return Assembly.LoadFile(assemblyProgramFilesFullName);
+            }
+            else
+            {
+                //Por causa dos Resources do ERP !!!
+                assemblyProgramFilesX86FullName = Path.Combine(Path.Combine(environmentVariablesProgramFilesX86, PRIMAVERA_FOLDER + "\\pt"), assemblyName.Name + ".dll");
+                assemblyProgramFilesFullName = Path.Combine(Path.Combine(environmentVariablesProgramFiles, PRIMAVERA_FOLDER + "\\pt"), assemblyName.Name + ".dll");
+                if (File.Exists(assemblyProgramFilesX86FullName))
+                {
+                    return Assembly.LoadFile(assemblyProgramFilesX86FullName);
+                }
+                else if (File.Exists(assemblyProgramFilesFullName))
+                {
+                    return Assembly.LoadFile(assemblyProgramFilesFullName);
+                }
+                else
+                {
+                    //Por causa do Processo de CefSharp !!!
+                    assemblyProgramFilesX86FullName = Path.Combine(Path.Combine(environmentVariablesProgramFilesX86, PRIMAVERA_FOLDER + "\\X86"), assemblyName.Name + ".dll");
+                    assemblyProgramFilesFullName = Path.Combine(Path.Combine(environmentVariablesProgramFiles, PRIMAVERA_FOLDER + "\\X64"), assemblyName.Name + ".dll");
+                    if (File.Exists(assemblyProgramFilesX86FullName))
+                    {
+                        return Assembly.LoadFile(assemblyProgramFilesX86FullName);
+                    }
+                    else if (File.Exists(assemblyProgramFilesFullName))
+                    {
+                        return Assembly.LoadFile(assemblyProgramFilesFullName);
+                    }
+                    else
+                    {
+                        //Por causa do Processo de HuRakan !!!
+                        assemblyProgramFilesX86FullName = Path.Combine(Path.Combine(environmentVariablesProgramFilesX86, PRIMAVERA_FOLDER + "\\HUR\\pt"), assemblyName.Name + ".dll");
+                        assemblyProgramFilesFullName = Path.Combine(Path.Combine(environmentVariablesProgramFiles, PRIMAVERA_FOLDER + "\\HUR\\pt"), assemblyName.Name + ".dll");
+                        if (File.Exists(assemblyProgramFilesX86FullName))
+                        {
+                            return Assembly.LoadFile(assemblyProgramFilesX86FullName);
+                        }
+                        else if (File.Exists(assemblyProgramFilesFullName))
+                        {
+                            return Assembly.LoadFile(assemblyProgramFilesFullName);
+                        }
+                        else
+                        {
+                            return null;
+                        }
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Update method CurrentDomain_AssemblyResolve for more checks case variable "PERCURSOSGE100" won't exist or other dependencies are requested to resolve.